### PR TITLE
Tuple elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) since v2.0.0.
 
 ## [Unreleased]
+### Added
+- New tuple 2 and 3-tuple of `int` and `str` as available `cpp_type`.
+- A samplable set can be instanciated empty without specifying the `cpp_type`.
+  It will be inferred at the first insertion.
+
+### Fixed
+Test for out of bound weight.
+
+## [v2.0.1] - 2020-06-26
 ### Changed
 - Class name in C++
 - RNG is now a static member of C++ `BaseSamplableSet` class. This means all
@@ -55,7 +64,8 @@ Merged the fork from jsleb333, providing a pythonic wrapper.
 
 First release with the old wrapper using C++ style.
 
-[Unreleased]: https://github.com/gstonge/SamplableSet/compare/v1.0.8...HEAD
+[Unreleased]: https://github.com/gstonge/SamplableSet/compare/v2.0.1...HEAD
+[v1.0.8]: https://github.com/gstonge/SamplableSet/compare/v1.0.8...v2.0.1
 [v1.0.8]: https://github.com/gstonge/SamplableSet/compare/v1.0.6...v1.0.8
 [v1.0.6]: https://github.com/gstonge/SamplableSet/compare/v1.0.2...v1.0.6
 [v1.0.2]: https://github.com/gstonge/SamplableSet/compare/v1.0.0...v1.0.2

--- a/README.md
+++ b/README.md
@@ -53,17 +53,21 @@ To expose a new C++ samplable set to python, one needs to bind the class to pybi
     ├── bind_SamplableSet.hpp
 ```
 
-To further wrap this new object to SamplableSet, it needs to be added to the python wrapper.
+To further wrap this new object to SamplableSet, it needs to be added to the python wrapper, and a `cpp_type` label must be given.
 
 ```
 ├── SamplableSet
     ├── _wrapper.py
 ```
 
-Once this is done, the class can be used elegantly in python. Basic types are already implemented :
+Once this is done, the class can be used elegantly in python. Basic `cpp_type` are already implemented :
 
 * `int`
 * `str`
+* `2int` (tuple of 2 `int`)
+* `3int` (tuple of 3 `int`)
+* `2str` (tuple of 2 `str`)
+* `3str` (tuple of 3 `str`)
 
 
 ## Usage
@@ -72,23 +76,29 @@ The package offers both a C++ and a python style interface for the class in pyth
 
 ### Set creation
 
-First to create an empty samplable set, one needs to specify the minimal (maximal) weight for elements in the set, as well as the C++ type of the elements that will be inserted in the set. An non-empty set can be instanciated from an iterable of 2 iterables or a dict containing the elements and the weights.
+First to create an empty samplable set, one needs to specify the minimal (maximal) weight for elements in the set.
+One can specify the C++ type of the elements that will be inserted in the set,
+or it will be inferred the first time an element is inserted.
+An non-empty set can also be instanciated from an iterable of 2 iterables or a dict containing the elements and the weights.
 
 ```python
 from SamplableSet import SamplableSet
+
+# Calling the default constructor for empty samplable set without type
+s = SamplableSet(min_weight=1, max_weight=100)
 
 # Calling the default constructor for empty samplable set
 s = SamplableSet(min_weight=1, max_weight=100, cpp_type='int')
 
 # Calling the constructor with a dict
 elements_weights = {3:33.3, 6:66.6}
-s = SamplableSet(1, 100, elements_weights) # cpp_type is infered from 'elements_weights'
+s = SamplableSet(1, 100, elements_weights) # cpp_type is inferred from 'elements_weights'
 
 # Calling the constructor with an iterable of pairs (elements, weights)
 elements = ['a', 'b']
 weights = [33.3, 66.6]
 elements_weights = zip(elements, weights)
-s = SamplableSet(1, 100, elements_weights) # cpp_type is infered from 'elements_weights'
+s = SamplableSet(1, 100, elements_weights) # cpp_type is inferred from 'elements_weights'
 ```
 
 ### Seeding the PRNG

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ from setuptools.command.build_ext import build_ext
 import sys
 import setuptools
 
-__version__ = '2.0.1'
+__version__ = '2.1.0'
 
 
 class get_pybind_include(object):

--- a/src/bind_SamplableSet.cpp
+++ b/src/bind_SamplableSet.cpp
@@ -32,6 +32,11 @@ using namespace sset;
 
 namespace py = pybind11;
 
+typedef tuple<int,int> Tuple2Int;
+typedef tuple<int,int,int> Tuple3Int;
+typedef tuple<string,string> Tuple2String;
+typedef tuple<string,string,string> Tuple3String;
+
 //template function to declare different types of samplable set
 template<typename T>
 void declare_samplable_set(py::module &m, string typestr)
@@ -130,4 +135,8 @@ PYBIND11_MODULE(_SamplableSet, m)
 {
     declare_samplable_set<int>(m, "Int");
     declare_samplable_set<string>(m, "String");
+    declare_samplable_set<Tuple2Int>(m, "Tuple2Int");
+    declare_samplable_set<Tuple3Int>(m, "Tuple3Int");
+    declare_samplable_set<Tuple2String>(m, "Tuple2String");
+    declare_samplable_set<Tuple3String>(m, "Tuple3String");
 }

--- a/test/test_basic_operations.py
+++ b/test/test_basic_operations.py
@@ -88,4 +88,9 @@ class TestInitialization:
         with pytest.raises(ValueError):
             s = SamplableSet(1, np.inf)
 
+    def test_throw_error_3(self):
+        with pytest.raises(ValueError):
+            s = SamplableSet(2, 1)
+
+
 

--- a/test/test_basic_operations.py
+++ b/test/test_basic_operations.py
@@ -74,6 +74,12 @@ class TestInitialization:
         s = SamplableSet(1, 100, elements_weights)
         assert 'a' in s and 'b' in s
 
+    def test_empty_init(self):
+        s = SamplableSet(1,100)
+        assert s.cpp_type is None
+        s['a'] = 2
+        assert s.cpp_type == 'str'
+
     def test_throw_error_1(self):
         with pytest.raises(ValueError):
             s = SamplableSet(0, 100)


### PR DESCRIPTION
### Added
- New tuple 2 and 3-tuple of `int` and `str` as available `cpp_type`.
- A samplable set can be instanciated empty without specifying the `cpp_type`.
  It will be inferred at the first insertion.

### Fixed
Test for out of bound weight.
