### PR TITLE
Compile to static library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ from setuptools.command.build_ext import build_ext
 import sys
 import setuptools
 
-__version__ = '2.1.0'
+__version__ = '2.1.1'
 
 
 class get_pybind_include(object):

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ ext_modules = [
     Extension(
         '_SamplableSet',
         ['src/bind_SamplableSet.cpp', 'src/HashPropensity.cpp',
-         'src/BinaryTree.cpp'],
+         'src/BinaryTree.cpp', 'src/SamplableSet.cpp'],
         include_dirs=[
             'src/',
             get_pybind_include(),

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.17 FATAL_ERROR)
 project(SamplableSet)
 set(CMAKE_CXX_STANDARD 17)
 
-add_library(SAMPLABLE_SET
+add_library(samplableset
     BinaryTree.cpp
     HashPropensity.cpp
     SamplableSet.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,4 +6,5 @@ set(CMAKE_CXX_STANDARD 17)
 add_library(SAMPLABLE_SET
     BinaryTree.cpp
     HashPropensity.cpp
+    SamplableSet.cpp
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.17 FATAL_ERROR)
+
+project(SamplableSet)
+set(CMAKE_CXX_STANDARD 17)
+
+add_library(SAMPLABLE_SET
+    BinaryTree.cpp
+    HashPropensity.cpp
+)

--- a/src/SamplableSet.cpp
+++ b/src/SamplableSet.cpp
@@ -1,0 +1,11 @@
+#include "SamplableSet.hpp"
+
+
+sset::RNGType sset::BaseSamplableSet::gen_ = RNGType(time(NULL));
+
+
+//seed the RNG
+void sset::BaseSamplableSet::seed(unsigned int seed_value)
+{
+    BaseSamplableSet::gen_.seed(seed_value);
+}

--- a/src/SamplableSet.hpp
+++ b/src/SamplableSet.hpp
@@ -52,13 +52,6 @@ class BaseSamplableSet
         static RNGType gen_;
 };
 
-RNGType BaseSamplableSet::gen_ = RNGType(time(NULL));
-
-//seed the RNG
-void BaseSamplableSet::seed(unsigned int seed_value)
-{
-    BaseSamplableSet::gen_.seed(seed_value);
-}
 
 /*
  * Set of elements, samplable efficiently using composition and rejection


### PR DESCRIPTION
Add CMakeLists.txt to compile all .cpp files into a static library. Move definition of static variable and seed method of BaseSamplableSet into SamplableSet.cpp to prevent collision when linking the static library.

These modifications make possible the use of the SamplableSet class in another C++ project by linking the static library and including the src/ directory containing the header files.