### PR TITLE
Dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) since v2.0.0.
 
+## [v2.1.2] - 2020-07-21
+### Added
+- Bound check-up for the weight of elements in C++ (insertion, set weight).
+- New `empty` method to test if the set is empty.
+
+### Changed
+- Bound checking (exception throw) is now mainly done in C++.
+
+### Fixed
+- In python, if one checks the weight of an element not in the set, it
+  now returns `None`.
 
 ## [v2.1.1] - 2020-07-10
 ### Added
@@ -68,6 +79,7 @@ Merged the fork from jsleb333, providing a pythonic wrapper.
 
 First release with the old wrapper using C++ style.
 
+[v2.1.2]: https://github.com/gstonge/SamplableSet/compare/v2.1.1...v2.1.2
 [v2.1.1]: https://github.com/gstonge/SamplableSet/compare/v2.0.1...v2.1.1
 [v2.0.1]: https://github.com/gstonge/SamplableSet/compare/v1.0.8...v2.0.1
 [v1.0.8]: https://github.com/gstonge/SamplableSet/compare/v1.0.6...v1.0.8

--- a/SamplableSet/_wrapper.py
+++ b/SamplableSet/_wrapper.py
@@ -127,10 +127,7 @@ class SamplableSet:
                 self.min_weight,self.max_weight)
             self._wrap_methods()
         if self.min_weight <= weight <= self.max_weight:
-            if element in self:
-                self.set_weight(element, weight)
-            else:
-                self.insert(element, weight)
+            self.set_weight(element,weight)
         else:
             raise ValueError(f'Cannot assign weight outside range [{self.min_weight}, {self.max_weight}].')
 

--- a/SamplableSet/_wrapper.py
+++ b/SamplableSet/_wrapper.py
@@ -117,7 +117,7 @@ class SamplableSet:
         return True if self.count(element) else False
 
     def __getitem__(self, element):
-        return self.get_weight(element) or 0
+        return self.get_weight(element)
 
     def __setitem__(self, element, weight):
         if self.cpp_type is None:

--- a/SamplableSet/_wrapper.py
+++ b/SamplableSet/_wrapper.py
@@ -109,7 +109,7 @@ class SamplableSet:
         Assigns the methods of the C++ class to the wrapper.
         """
         for func_name in ['size', 'total_weight', 'count', 'insert', 'next',
-                          'init_iterator', 'set_weight', 'get_weight',
+                          'init_iterator', 'set_weight', 'get_weight', 'empty',
                           'get_at_iterator', 'erase', 'clear']:
             setattr(self, func_name, getattr(self._samplable_set, func_name))
 

--- a/SamplableSet/_wrapper.py
+++ b/SamplableSet/_wrapper.py
@@ -126,10 +126,7 @@ class SamplableSet:
             self._samplable_set = template_classes[self.cpp_type](
                 self.min_weight,self.max_weight)
             self._wrap_methods()
-        if self.min_weight <= weight <= self.max_weight:
-            self.set_weight(element,weight)
-        else:
-            raise ValueError(f'Cannot assign weight outside range [{self.min_weight}, {self.max_weight}].')
+        self.set_weight(element,weight)
 
     def __delitem__(self, element):
         self.erase(element)

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ from setuptools.command.build_ext import build_ext
 import sys
 import setuptools
 
-__version__ = '2.1.1'
+__version__ = '2.1.2'
 
 
 class get_pybind_include(object):

--- a/src/SamplableSet.hpp
+++ b/src/SamplableSet.hpp
@@ -71,6 +71,7 @@ public:
 
     //Accessors
     std::size_t size() const {return position_map_.size();}
+    bool empty() const {return size() == 0;}
     std::size_t inline count(const T& element) const
         {return position_map_.count(element);}
     std::optional<std::pair<T,double> > sample() const;
@@ -145,7 +146,7 @@ SamplableSet<T>::SamplableSet(const SamplableSet<T>& s) :
 template <typename T>
 std::optional<std::pair<T,double> > SamplableSet<T>::sample() const
 {
-    if (sampling_tree_.get_value() > 0)
+    if (not empty())
     {
         GroupIndex group_index = sampling_tree_.get_leaf_index(random_01_(gen_));
         bool element_not_chosen = true;
@@ -176,7 +177,7 @@ template <typename T>
 template <typename ExtRNG>
 std::optional<std::pair<T,double> > SamplableSet<T>::sample_ext_RNG(ExtRNG& gen) const
 {
-    if (sampling_tree_.get_value() > 0)
+    if (not empty())
     {
         GroupIndex group_index = sampling_tree_.get_leaf_index(random_01_(gen));
         bool element_not_chosen = true;

--- a/src/SamplableSet.hpp
+++ b/src/SamplableSet.hpp
@@ -34,6 +34,7 @@
 #include <optional>
 #include <stdio.h>
 #include <time.h>
+#include <stdexcept>
 
 namespace sset
 {//start of namespace sset
@@ -91,6 +92,8 @@ public:
 
 
 private:
+    double min_weight_;
+    double max_weight_;
     mutable std::uniform_real_distribution<double> random_01_;
     HashPropensity hash_;
     unsigned int number_of_group_;
@@ -100,12 +103,16 @@ private:
     std::vector<PropensityGroup> propensity_group_vector_;
     mutable typename PropensityGroup::iterator iterator_;
     mutable GroupIndex iterator_group_index_;
+    //private method
+    void weight_checkup(double weight) const;
 };
 
 
 //Default constructor for the class SamplableSet
 template <typename T>
 SamplableSet<T>::SamplableSet(double min_weight, double max_weight) :
+    min_weight_(min_weight),
+    max_weight_(max_weight),
     random_01_(0.,1.),
     hash_(min_weight, max_weight),
     number_of_group_(hash_(max_weight)+1),
@@ -140,6 +147,16 @@ SamplableSet<T>::SamplableSet(const SamplableSet<T>& s) :
     iterator_(),
     iterator_group_index_(0)
 {
+}
+
+//throw a invalid_argument error if the weight is out of bounds
+template <typename T>
+void SamplableSet<T>::weight_checkup(double weight) const
+{
+    if (weight < min_weight_ or weight > max_weight_)
+    {
+        throw std::invalid_argument("Weight out of bounds");
+    }
 }
 
 //sample an element according to its weight
@@ -223,7 +240,8 @@ std::optional<double> SamplableSet<T>::get_weight(const T& element) const
 template <typename T>
 void SamplableSet<T>::insert(const T& element, double weight)
 {
-    //insert element only if not present
+    weight_checkup(weight);
+    //insert element only if not present and the weight is acceptable
     if (position_map_.find(element) == position_map_.end())
     {
         GroupIndex group_index = hash_(weight);
@@ -241,6 +259,7 @@ void SamplableSet<T>::insert(const T& element, double weight)
 template <typename T>
 void SamplableSet<T>::set_weight(const T& element, double weight)
 {
+    weight_checkup(weight);
     erase(element);
     insert(element, weight);
 }

--- a/src/SamplableSet.hpp
+++ b/src/SamplableSet.hpp
@@ -241,7 +241,7 @@ template <typename T>
 void SamplableSet<T>::insert(const T& element, double weight)
 {
     weight_checkup(weight);
-    //insert element only if not present and the weight is acceptable
+    //insert element only if not present
     if (position_map_.find(element) == position_map_.end())
     {
         GroupIndex group_index = hash_(weight);

--- a/src/bind_SamplableSet.cpp
+++ b/src/bind_SamplableSet.cpp
@@ -64,6 +64,10 @@ void declare_samplable_set(py::module &m, string typestr)
             Returns the number of elements in the set.
             )pbdoc")
 
+        .def("empty", &SamplableSet<T>::empty, R"pbdoc(
+            Returns true if the set is empty.
+            )pbdoc")
+
         .def("total_weight", &SamplableSet<T>::total_weight, R"pbdoc(
             Returns the sum of the weights of the elements in the set.
             )pbdoc")

--- a/test/test_basic_operations.py
+++ b/test/test_basic_operations.py
@@ -47,6 +47,24 @@ class TestContainerModification:
          s['a'] = 3.
          assert s['a'] == 3. and len(s) == 1 and s.total_weight() == 3.
 
+    def test_throw_error_1(self):
+        with pytest.raises(ValueError):
+            s = SamplableSet(1, 10)
+            s['a'] = 0.5
+
+    def test_throw_error_2(self):
+        with pytest.raises(ValueError):
+            s = SamplableSet(1, 10)
+            s['a'] = 2.
+            s['b'] = 0.5
+
+    def test_throw_error_3(self):
+        with pytest.raises(ValueError):
+            s = SamplableSet(1, 10)
+            s['a'] = 2.
+            s['a'] = 11
+
+
 
 class TestSampling:
     def test_sampling_single(self):

--- a/test/test_basic_operations.py
+++ b/test/test_basic_operations.py
@@ -31,6 +31,21 @@ class TestContainerModification:
          del s['a']
          assert len(s) == 0 and s.empty()
 
+    def test_get_weight(self):
+         s = SamplableSet(1, 10)
+         s['a'] = 2.
+         assert s['a'] == 2.
+
+    def test_get_weight_no_item(self):
+         s = SamplableSet(1, 10)
+         s['a'] = 2.
+         assert s['b'] is None
+
+    def test_set_weight(self):
+         s = SamplableSet(1, 10)
+         s['a'] = 2.
+         s['a'] = 3.
+         assert s['a'] == 3. and len(s) == 1 and s.total_weight() == 3.
 
 
 class TestSampling:

--- a/test/test_basic_operations.py
+++ b/test/test_basic_operations.py
@@ -104,8 +104,9 @@ class TestInitialization:
     def test_empty_init(self):
         s = SamplableSet(1,100)
         assert s.cpp_type is None
-        s['a'] = 2
+        s['a'] = 2.
         assert s.cpp_type == 'str'
+        assert len(s) == 1 and s['a'] == 2.
 
     def test_throw_error_1(self):
         with pytest.raises(ValueError):

--- a/test/test_basic_operations.py
+++ b/test/test_basic_operations.py
@@ -18,7 +18,19 @@ class TestContainerModification:
         elements_weights = zip(elements, weights)
         s = SamplableSet(1, 100, elements_weights)
         s.clear()
-        assert s.total_weight() == 0 and len(s) == 0 and s.sample() is None
+        assert s.total_weight() == 0 and len(s) == 0 and s.sample() is None and s.empty()
+
+    def test_insert(self):
+         s = SamplableSet(1, 10)
+         s['a'] = 2.
+         assert len(s) == 1 and not s.empty()
+
+    def test_erase(self):
+         s = SamplableSet(1, 10)
+         s['a'] = 2.
+         del s['a']
+         assert len(s) == 0 and s.empty()
+
 
 
 class TestSampling:


### PR DESCRIPTION
### Added
- Bound check-up for the weight of elements in C++ (insertion, set weight).
- New `empty` method to test if the set is empty.

### Changed
- Bound checking (exception throw) is now mainly done in C++.

### Fixed
- In python, if one checks the weight of an element not in the set, it
  now returns `None`.
