### PR TITLE
C++ methods raise error message until type specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - The `__str__` method now works with SamplableSet of unspecified underlying
   type.
+- All C++ methods (e.g. `size`) raise an error message until the type is
+  specified/inferred.
 
 ## [v2.1.3] - 2020-12-14
 ### Added

--- a/SamplableSet/_wrapper.py
+++ b/SamplableSet/_wrapper.py
@@ -38,6 +38,10 @@ template_classes = {
     'Tuple3String': Tuple3StringSamplableSet
 }
 
+cpp_methods = ['size', 'total_weight', 'count', 'insert', 'next',
+               'init_iterator', 'set_weight', 'get_weight', 'empty',
+               'get_at_iterator', 'erase', 'clear']
+
 class SamplableSet:
     """
     This class implements a set which is samplable according to the weight distribution of the elements.
@@ -78,6 +82,8 @@ class SamplableSet:
         if self.cpp_type is not None:
             self._samplable_set = template_classes[self.cpp_type](min_weight, max_weight)
             self._wrap_methods()
+        else:
+            self._wrap_methods_unspecified()
 
         # Initialize the set
         if elements_weights:
@@ -104,13 +110,22 @@ class SamplableSet:
             else:
                 raise ValueError('Cannot infer the type from the element')
 
+    def _unspecified_method(self):
+        raise RuntimeError('The method is undefined until the underlying type is known')
+
+    def _wrap_methods_unspecified(self):
+        """
+        Assigns the methods of the C++ class to a dummy method that raises
+        a RuntimeError
+        """
+        for func_name in cpp_methods:
+            setattr(self, func_name, self._unspecified_method)
+
     def _wrap_methods(self):
         """
         Assigns the methods of the C++ class to the wrapper.
         """
-        for func_name in ['size', 'total_weight', 'count', 'insert', 'next',
-                          'init_iterator', 'set_weight', 'get_weight', 'empty',
-                          'get_at_iterator', 'erase', 'clear']:
+        for func_name in cpp_methods:
             setattr(self, func_name, getattr(self._samplable_set, func_name))
 
     def __contains__(self, element):

--- a/test/test_basic_operations.py
+++ b/test/test_basic_operations.py
@@ -119,12 +119,19 @@ class TestInitialization:
         s = SamplableSet(1, 100, elements_weights)
         assert 'a' in s and 'b' in s
 
-    def test_empty_init(self):
+    def test_empty_init_1(self):
         s = SamplableSet(1,100)
         assert s.cpp_type is None
         s['a'] = 2.
         assert s.cpp_type == 'str'
         assert len(s) == 1 and s['a'] == 2.
+
+    def test_empty_init_2(self):
+        s = SamplableSet(1,100, {})
+        assert s.cpp_type is None
+        s[1] = 5.
+        assert s.cpp_type == 'int'
+        assert len(s) == 1 and s[1] == 5.
 
     def test_throw_error_1(self):
         with pytest.raises(ValueError):
@@ -138,5 +145,12 @@ class TestInitialization:
         with pytest.raises(ValueError):
             s = SamplableSet(2, 1)
 
+    def test_throw_error_4(self):
+        with pytest.raises(RuntimeError):
+            s = SamplableSet(1, 2)
+            s.size()
 
-
+    def test_throw_error_5(self):
+        with pytest.raises(RuntimeError):
+            s = SamplableSet(1, 2)
+            s.total_weight()


### PR DESCRIPTION
### Fixed
- All C++ methods (e.g. `size`) raise an error message until the type is
  specified/inferred.
