### PR TITLE
Cpp11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) since v2.0.0.
 
+## [v2.2.0] - 2021-04-26
+
+### Changed
+- Now compatible with C++11.
+- When sampling an empty set, it raises a `KeyError` instead or returning a
+  `None`. This also affects the behavior of sampling without replacement when
+  `n_samples`is larger than the set size.
+- Other forbidden operations raises an error as well instead of returning a
+  `None`.
+
+
 ## [v2.1.4] - 2021-02-02
 ### Fixed
 - The `__str__` method now works with SamplableSet of unspecified underlying
@@ -93,6 +104,7 @@ Merged the fork from jsleb333, providing a pythonic wrapper.
 
 First release with the old wrapper using C++ style.
 
+[v2.2.0]: https://github.com/gstonge/SamplableSet/compare/v2.1.4...v2.2.0
 [v2.1.4]: https://github.com/gstonge/SamplableSet/compare/v2.1.3...v2.1.4
 [v2.1.3]: https://github.com/gstonge/SamplableSet/compare/v2.1.2...v2.1.3
 [v2.1.2]: https://github.com/gstonge/SamplableSet/compare/v2.1.1...v2.1.2

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Changes are listed in the [changelog](CHANGELOG.md).
 
 ## Requirements and dependencies
 
-* A compiler with C++17 support
+* A compiler with C++11 support
 * `python3`
 * `pybind11` version >= 2.2
 
@@ -167,8 +167,7 @@ for element, weight in s.sample(n_samples=5):
 ```
 
 It is possible to sample without replacement as well. If `n_samples` is larger
-than the number of elements, the generator returns `None` for the remaining
-samples. It is not safe to unpack directly, unless `n_samples <= len(s)`.
+than the number of elements, it raises a `KeyError`.
 
 ```python
 elements_weights = {3:33.3}
@@ -176,7 +175,7 @@ s = SamplableSet(1, 100, elements_weights)
 x_list = []
 for x in s.sample(n_samples=2,replace=False):
     x_list.append(x)
-# x_list == [(3,33.3),None] is True
+# KeyError is raised
 ```
 
 ### Copy

--- a/SamplableSet/_wrapper.py
+++ b/SamplableSet/_wrapper.py
@@ -86,9 +86,10 @@ class SamplableSet:
             if isinstance(elements_weights, dict):
                 elements_weights = elements_weights.items()
 
-            # Inferring cpp_type
             first_element, first_weight = next(iter(elements_weights))
-            self._infer_type(first_element)
+            # Inferring cpp_type
+            if self.cpp_type is None:
+                self._infer_type(first_element)
 
         # Instanciate the set
         if self.cpp_type is not None:

--- a/SamplableSet/_wrapper.py
+++ b/SamplableSet/_wrapper.py
@@ -205,10 +205,13 @@ class SamplableSet:
             yield x
 
     def element_generator(self):
-        self.init_iterator()
-        while self.get_at_iterator() is not None:
-            yield self.get_at_iterator()
-            self.next()
+        try:
+            self.init_iterator()
+            while True:
+                yield self.get_at_iterator()
+                self.next()
+        except StopIteration:
+            pass
 
     @staticmethod
     def seed(seed_value):

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ from setuptools.command.build_ext import build_ext
 import sys
 import setuptools
 
-__version__ = '2.1.4'
+__version__ = '2.1.5'
 
 
 class get_pybind_include(object):
@@ -92,14 +92,14 @@ def has_flag(compiler, flagname):
 
 
 def cpp_flag(compiler):
-    """Return the -std=c++17 compiler flag.
+    """Return the -std=c++11 compiler flag.
 
-    c++17 is required.
+    c++11 is required.
     """
-    if has_flag(compiler, '-std=c++17'):
-        return '-std=c++17'
+    if has_flag(compiler, '-std=c++11'):
+        return '-std=c++11'
     else:
-        raise RuntimeError('Unsupported compiler -- at least C++17 support '
+        raise RuntimeError('Unsupported compiler -- at least C++11 support '
                            'is needed!')
 
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ from setuptools.command.build_ext import build_ext
 import sys
 import setuptools
 
-__version__ = '2.1.5'
+__version__ = '2.1.6'
 
 
 class get_pybind_include(object):

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ from setuptools.command.build_ext import build_ext
 import sys
 import setuptools
 
-__version__ = '2.1.6'
+__version__ = '2.2.0'
 
 
 class get_pybind_include(object):

--- a/src/SamplableSet.hpp
+++ b/src/SamplableSet.hpp
@@ -35,7 +35,6 @@
 #include <time.h>
 #include <string>
 #include <stdexcept>
-#include <pybind11/pybind11.h>
 
 namespace sset
 {//start of namespace sset
@@ -191,7 +190,7 @@ std::pair<T,double> SamplableSet<T>::sample() const
     else
     {
         std::string out = "The Samplableset is empty";
-        throw pybind11::key_error(out);
+        throw std::out_of_range(out);
     }
 
     return propensity_group_vector_.at(group_index).at(in_group_index);
@@ -225,7 +224,7 @@ std::pair<T,double>SamplableSet<T>::sample_ext_RNG(ExtRNG& gen) const
     else
     {
         std::string out = "The Samplableset is empty";
-        throw pybind11::key_error(out);
+        throw std::out_of_range(out);
     }
 
     return propensity_group_vector_.at(group_index).at(in_group_index);
@@ -244,7 +243,7 @@ double SamplableSet<T>::get_weight(const T& element) const
      else
     {
         std::string out = "Key error, the element is not in the set";
-        throw pybind11::key_error(out);
+        throw std::out_of_range(out);
     }
 
     return weight;
@@ -336,7 +335,7 @@ void SamplableSet<T>::next()
     }
     if (iterator_ == propensity_group_vector_.back().end())
     {
-        throw pybind11::stop_iteration("");
+        throw std::out_of_range("");
     }
 }
 
@@ -370,7 +369,7 @@ void SamplableSet<T>::init_iterator()
     //throw stop iteration error if empty
     if (iterator_ == propensity_group_vector_.back().end())
     {
-        throw pybind11::stop_iteration("");
+        throw std::out_of_range("");
     }
 }
 

--- a/src/SamplableSet.hpp
+++ b/src/SamplableSet.hpp
@@ -189,7 +189,7 @@ std::pair<T,double> SamplableSet<T>::sample() const
     }
     else
     {
-        std::string out = "The Samplableset is empty";
+        std::string out = "The samplable set is empty";
         throw std::out_of_range(out);
     }
 
@@ -223,7 +223,7 @@ std::pair<T,double>SamplableSet<T>::sample_ext_RNG(ExtRNG& gen) const
     }
     else
     {
-        std::string out = "The Samplableset is empty";
+        std::string out = "The samplable set is empty";
         throw std::out_of_range(out);
     }
 

--- a/test/test_basic_operations.py
+++ b/test/test_basic_operations.py
@@ -18,7 +18,9 @@ class TestContainerModification:
         elements_weights = zip(elements, weights)
         s = SamplableSet(1, 100, elements_weights)
         s.clear()
-        assert s.total_weight() == 0 and len(s) == 0 and s.sample() is None and s.empty()
+        assert s.total_weight() == 0 and len(s) == 0 and s.empty()
+        with pytest.raises(KeyError):
+            s.sample()
 
     def test_insert(self):
          s = SamplableSet(1, 10)
@@ -39,7 +41,8 @@ class TestContainerModification:
     def test_get_weight_no_item(self):
          s = SamplableSet(1, 10)
          s['a'] = 2.
-         assert s['b'] is None
+         with pytest.raises(KeyError):
+            s['b']
 
     def test_set_weight(self):
          s = SamplableSet(1, 10)
@@ -47,18 +50,18 @@ class TestContainerModification:
          s['a'] = 3.
          assert s['a'] == 3. and len(s) == 1 and s.total_weight() == 3.
 
-    def test_throw_error_1(self):
+    def test_weight_out_of_bound(self):
         with pytest.raises(ValueError):
             s = SamplableSet(1, 10)
             s['a'] = 0.5
 
-    def test_throw_error_2(self):
+    def test_weight_out_of_bound_2(self):
         with pytest.raises(ValueError):
             s = SamplableSet(1, 10)
             s['a'] = 2.
             s['b'] = 0.5
 
-    def test_throw_error_3(self):
+    def test_weight_out_of_bound_3(self):
         with pytest.raises(ValueError):
             s = SamplableSet(1, 10)
             s['a'] = 2.
@@ -96,14 +99,25 @@ class TestSampling:
         assert element == 'a' and weight == 33.3 and len(s) == 0
 
     def test_sampling_no_replacement_generator(self):
-        elements = ['a']
-        weights = [33.3]
+        elements = ['a','b']
+        weights = [33.3,50.]
         elements_weights = zip(elements, weights)
         s = SamplableSet(1, 100, elements_weights)
         sample_list = []
-        for sample in s.sample(n_samples=5,replace=False):
+        for sample in s.sample(n_samples=2,replace=False):
             sample_list.append(sample)
-        assert sample_list == [('a',33.3),None,None,None,None] and len(s) == 0
+        assert sample_list[0][0] in elements and sample_list[1][0] in elements
+        assert len(s) == 0
+
+    def test_sampling_no_replacement_generator_error(self):
+        elements = ['a','b']
+        weights = [33.3,50.]
+        elements_weights = zip(elements, weights)
+        s = SamplableSet(1, 100, elements_weights)
+        sample_list = []
+        with pytest.raises(KeyError):
+            for sample in s.sample(n_samples=3,replace=False):
+                sample_list.append(sample)
 
 
 class TestInitialization:

--- a/test/test_iterator.py
+++ b/test/test_iterator.py
@@ -7,6 +7,7 @@ Author: Guillaume St-Onge <guillaume.st-onge.4@ulaval.ca>
 """
 
 from SamplableSet import SamplableSet
+import pytest
 
 class TestCppMethod:
     def test_init_iterator_1(self):
@@ -39,13 +40,13 @@ class TestCppMethod:
         s.next()
         assert s.get_at_iterator() == (2,50.)
 
-    def test_next_get_None(self):
+    def test_next_error(self):
         elements = {1:10, 2:50}
         s = SamplableSet(1,100,elements)
         s.init_iterator()
         s.next()
-        s.next()
-        assert s.get_at_iterator() is None
+        with pytest.raises(StopIteration):
+            s.next()
 
 
 def test_python_generator():
@@ -55,3 +56,10 @@ def test_python_generator():
     expected = zip(elements,weights)
     assert list(expected) == list(s.__iter__())
 
+def test_python_generator_empty():
+    elements = range(1,10)
+    weights = range(1,10)
+    s = SamplableSet(1,10,zip(elements,weights))
+    s.clear()
+    expected = []
+    assert list(expected) == list(s.__iter__())


### PR DESCRIPTION
- Now compatible with C++11.
- When sampling an empty set, it raises a `KeyError` instead or returning a
  `None`. This also affects the behavior of sampling without replacement when
  `n_samples`is larger than the set size.
- Other forbidden operations raises an error as well instead of returning a
  `None`.
