### PR TITLE
downgrade c++ standard 17 -> 11

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.17 FATAL_ERROR)
 
 project(SamplableSet)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 11)
 
 add_library(samplableset
     BinaryTree.cpp


### PR DESCRIPTION
Make CMake build consistent with the required C++ standard.