### PR TITLE
Set position independent code

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,3 +8,6 @@ add_library(samplableset
     HashPropensity.cpp
     SamplableSet.cpp
 )
+
+# Required to link SamplableSet in a shared library (e.g. other pybind module)
+set_target_properties(samplableset PROPERTIES POSITION_INDEPENDENT_CODE TRUE)


### PR DESCRIPTION
Allows to link SamplableSet in other shared libraries. Useful for other pybind11 modules. 